### PR TITLE
Updated the queries to work with 6.6.4

### DIFF
--- a/local/data/ui/views/top_data_generating_source_forwarder_analysis.xml
+++ b/local/data/ui/views/top_data_generating_source_forwarder_analysis.xml
@@ -26,12 +26,12 @@
       <chart>
         <title>Top $number_forwarders$ source forwarders and their average event streams over $max_kbps_sourcetype_avg$ kbps by sourcetype</title>
         <search>
-          <query>[search index=_internal $forwarder_name$ sourcetype=splunkd source="/opt/splunkforwarder/var/log/splunk/metrics.log" component=Metrics group=per_host_thruput host=*suf* 
+          <query>[search index=_internal host=$forwarder_name$ sourcetype=splunkd source="/opt/splunkforwarder/var/log/splunk/metrics.log" component=Metrics group=per_host_thruput 
 | stats avg(kbps) as max_kbps by series 
 | sort - max_kbps 
 | head $number_forwarders$ 
 | stats values(series) as host
-| eval search="(index=_internal sourcetype::splunkd source::/opt/splunkforwarder/var/log/splunk/metrics.log per_sourcetype_thruput host=$forwarder_name$) AND (".mvjoin(host," OR host::").")"]
+| eval search="(index=_internal sourcetype::splunkd source::/opt/splunkforwarder/var/log/splunk/metrics.log per_sourcetype_thruput host=$forwarder_name$) AND (host::".mvjoin(host," OR host::").")"]
 | stats avg(kbps) as max_kbps by series host
 | where max_kbps &gt; $max_kbps_sourcetype_avg$
 | xyseries host series max_kbps
@@ -56,12 +56,12 @@
       <chart>
         <title>Top $number_forwarders$ source forwarders with maximum throughput over $max_kbps_sourcetype_max$ kbps</title>
         <search>
-          <query>[search index=_internal $forwarder_name$ sourcetype=splunkd source="/opt/splunkforwarder/var/log/splunk/metrics.log" component=Metrics group=per_host_thruput host=*suf* 
+          <query>[search index=_internal host=$forwarder_name$ sourcetype=splunkd source="/opt/splunkforwarder/var/log/splunk/metrics.log" component=Metrics group=per_host_thruput 
 | stats max(kbps) as max_kbps by series 
 | sort - max_kbps 
 | head $number_forwarders$ 
 | stats values(series) as host
-| eval search="(index=_internal sourcetype::splunkd source::/opt/splunkforwarder/var/log/splunk/metrics.log per_sourcetype_thruput host=$forwarder_name$) AND (".mvjoin(host," OR host::").")"]
+| eval search="(index=_internal sourcetype::splunkd source::/opt/splunkforwarder/var/log/splunk/metrics.log per_sourcetype_thruput host=$forwarder_name$) AND (host::".mvjoin(host," OR host::").")"]
 | stats max(kbps) as max_kbps by series host
 | where max_kbps &gt; $max_kbps_sourcetype_max$
 | xyseries host series max_kbps
@@ -88,12 +88,12 @@
       <chart>
         <title>Top $number_forwarders$ source forwarders and their average event streams over $max_kbps_source$ kbps by source</title>
         <search>
-          <query>[search index=_internal $forwarder_name$ sourcetype=splunkd source="/opt/splunkforwarder/var/log/splunk/metrics.log" component=Metrics group=per_host_thruput host=*suf* 
+          <query>[search index=_internal host=$forwarder_name$ sourcetype=splunkd source="/opt/splunkforwarder/var/log/splunk/metrics.log" component=Metrics group=per_host_thruput  
 | stats avg(kbps) as max_kbps by series 
 | sort - max_kbps 
 | head $number_forwarders$ 
 | stats values(series) as host
-| eval search="(index=_internal sourcetype::splunkd source::/opt/splunkforwarder/var/log/splunk/metrics.log per_source_thruput host=$forwarder_name$) AND (".mvjoin(host," OR host::").")"]
+| eval search="(index=_internal sourcetype::splunkd source::/opt/splunkforwarder/var/log/splunk/metrics.log per_source_thruput host=$forwarder_name$) AND (host::".mvjoin(host," OR host::").")"]
 | stats avg(kbps) as max_kbps by series host
 | where max_kbps &gt; $max_kbps_source$
 | xyseries host series max_kbps
@@ -118,12 +118,12 @@
       <chart>
         <title>Top $number_forwarders$ source forwarders with maximum throughput over $max_kbps_index$ kbps by index</title>
         <search>
-          <query>[search index=_internal $forwarder_name$ sourcetype=splunkd source="/opt/splunkforwarder/var/log/splunk/metrics.log" component=Metrics group=per_host_thruput host=*suf* 
+          <query>[search index=_internal host=$forwarder_name$ sourcetype=splunkd source="/opt/splunkforwarder/var/log/splunk/metrics.log" component=Metrics group=per_host_thruput  
 | stats max(kbps) as max_kbps by series 
 | sort - max_kbps 
 | head $number_forwarders$ 
 | stats values(series) as host
-| eval search="(index=_internal sourcetype::splunkd source::/opt/splunkforwarder/var/log/splunk/metrics.log per_index_thruput host=$forwarder_name$) AND (".mvjoin(host," OR host::").")"]
+| eval search="(index=_internal sourcetype::splunkd source::/opt/splunkforwarder/var/log/splunk/metrics.log per_index_thruput host=$forwarder_name$) AND (host::".mvjoin(host," OR host::").")"]
 | stats max(kbps) as max_kbps by series host
 | where max_kbps &gt; $max_kbps_index$
 | xyseries host series max_kbps


### PR DESCRIPTION
i installed the app on a 6.6.4 instance and the dashboard returned no results, i found that in the initial search query there was a reference to "host=*suf*" (this host does not exist on my install) and that when the sub search returned its search command, the search was missing off the first host as the **host::** was not being added after the "... AND (" i.e. "... AND (host1 OR host::host2 OR host::host3)" the output of the subsearch now returns "... AND (**host::**host1 OR host::host2 OR host::host3)"